### PR TITLE
ci: update build job configuration in CI workflow

### DIFF
--- a/.github/workflows/ci-on-push-master.yml
+++ b/.github/workflows/ci-on-push-master.yml
@@ -7,7 +7,8 @@ env:
   DOTNET_NOLOGO: true
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
 jobs:
-  build:
+  tag:
+    permissions: write-all
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
- Add a new `tag` section to the `build` job.
- Set job permissions to `write-all`.
- Configure job to run on `ubuntu-latest`.
- Include checkout action to fetch all history for branches and tags with a depth of 50.