### PR TITLE
feat(middleware): add CorrelationIdMiddleware for request tracing. Closes #4

### DIFF
--- a/Red55.Mattermost.OpenId.Proxy/Middlewares/Kestrel/CorrelationIdMiddleware.cs
+++ b/Red55.Mattermost.OpenId.Proxy/Middlewares/Kestrel/CorrelationIdMiddleware.cs
@@ -1,0 +1,43 @@
+﻿namespace Red55.Mattermost.OpenId.Proxy.Middlewares.Kestrel
+{
+    public class CorrelationIdMiddleware
+    {
+        private const string _headerName = "X-Correlation-ID";
+        public static string HeaderName { get; private set; } = _headerName;
+        private readonly RequestDelegate _next;
+
+        public CorrelationIdMiddleware(RequestDelegate next)
+        {
+            _next = EnsureArg.IsNotNull (next, nameof (next));
+        }
+
+        public CorrelationIdMiddleware(RequestDelegate next, string headerName)
+        {
+            _next = EnsureArg.IsNotNull (next, nameof (next));
+            HeaderName = EnsureArg.IsNotNullOrEmpty (headerName);
+        }
+
+#pragma warning disable S2325 // Methods and properties that don't access instance data should be static
+        public Task Invoke(HttpContext context)
+        {
+            if (!context.Request.Headers.TryGetValue (HeaderName, out var correlationId))
+            {
+                if (string.IsNullOrEmpty (context.TraceIdentifier))
+                {
+                    correlationId = context.TraceIdentifier = Guid.CreateVersion7 ().ToString ();
+                }
+                else
+                {
+                    correlationId = context.TraceIdentifier;
+                }
+
+            }
+
+            context.Request.Headers[HeaderName] = correlationId;
+            context.Response.Headers.Append (HeaderName, correlationId);
+
+            return _next (context);
+        }
+#pragma warning restore S2325 // Methods and properties that don't access instance data should be static
+    }
+}

--- a/Red55.Mattermost.OpenId.Proxy/appsettings.yml
+++ b/Red55.Mattermost.OpenId.Proxy/appsettings.yml
@@ -20,7 +20,7 @@ Serilog:
   Enrich:
     - Name: WithCorrelationId
       Args: 
-        addValueIfHeaderAbsence: true
+        addValueIfHeaderAbsence: false
     - Name: WithExceptionDetails
       Args:
         DefaultDestructuringEnabled: true
@@ -36,7 +36,7 @@ Serilog:
       Args:
         formatter:
           type: "Serilog.Templates.ExpressionTemplate, Serilog.Expressions"
-          template: "[{@t:yyyy-MM-ddTHH:mm:ss} {@l:u3}] {@m}\n{@x}" # {Coalesce(CorrelationId, '00000000-0000-0000-0000-000000000000')}
+          template: "[{@t:yyyy-MM-ddTHH:mm:ss} {Coalesce(CorrelationId, '0000000000000:00000000')} {@l:u3}] {@m}\n{@x}"
 
 Kestrel:
   Endpoints:


### PR DESCRIPTION
feat(middleware): add CorrelationIdMiddleware for request tracing. Closes #4

- Implement `CorrelationIdMiddleware` to manage correlation IDs in HTTP requests and responses.
- Update logging configuration in `Program.cs` to include coalesced correlation IDs in console output.
- Modify `appsettings.yml` to adjust Serilog settings for correlation ID handling.

#### PR Classification
New feature to implement correlation ID management in HTTP requests and responses.

#### PR Summary
This pull request introduces a `CorrelationIdMiddleware` to handle correlation IDs in HTTP requests and responses, ensuring consistent tracking across services. 
- **CorrelationIdMiddleware.cs**: Added a new middleware class to manage correlation IDs, including logic for generating and appending IDs to requests and responses.
- **Program.cs**: Registered the new middleware in the application pipeline and updated the console logging template to include a default correlation ID value.
- **appsettings.yml**: Modified Serilog configuration to change the `addValueIfHeaderAbsence` setting from `true` to `false` and updated the console logging template for correlation IDs.
