### PR TITLE
feat(gitlab): enhance PAT management and configuration. closes #1

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ docker pull red55/mm-openid-proxy:latest
 
 ## Configuration
 
+The web service automatically rotates GitLab Personal Access Token (PAT) before AppConfig.GitLab.PAT.GracePeriod its expiration date.
+So you have to bind AppConfig.GitLab.PAT.StoreLocation to a persistent volume to keep the token between container restarts.
+
+
 ```yaml
 AppConfig:
   OpenId:

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ docker pull red55/mm-openid-proxy:latest
 ## Pre-requisites
 
 1. Create a new Admin user in GitLab.
-2. Create Personal Access Token with `api` scope. Set it in `appsettings.yml`.
+2. Create Personal Access Token with **`[api,self_rotate]`** scopes. Set it in `appsettings.yml`.
 3. Create a new client in OpenId authorization service. Put its credentials in `appsettings.yml`.
 4. Don't forget to change OpenId and GitLab URLs in `appsettings.yml` to your own.
 
@@ -28,11 +28,14 @@ docker pull red55/mm-openid-proxy:latest
 AppConfig:
   OpenId:
     Url: "https://kc.apps.yunqi.studio"
-    AppId: "<OID CLIENT ID HERE>"
-    AppSecret: "<OID CLIENT PASSWORD HERE>"
+    AppId: "<OpenID CLIENT ID HERE>"
+    AppSecret: "<OpenID CLIENT PASSWORD HERE>"
   GitLab:
     Url: "http://gitlab.apps.yunqi.studio"
-    PAT: "<YOUR PAT HERE>"
+    PAT:
+      BootstrapToken: "<GitLab PAT HERE>"
+      StoreLocation: "/home/app/.gitlab/pat"
+      GracePeriod: "1.00:30:00" # 1 day 30 minutes
 ```
 
 The YAML configuration file could be overridden by environment variables.

--- a/Red55.Mattermost.OpenId.Proxy/Api/Gitlab/PersonalAccessTokens.cs
+++ b/Red55.Mattermost.OpenId.Proxy/Api/Gitlab/PersonalAccessTokens.cs
@@ -1,0 +1,18 @@
+﻿using Red55.Mattermost.OpenId.Proxy.Models.Gitlab;
+
+using Refit;
+
+namespace Red55.Mattermost.OpenId.Proxy.Api.Gitlab
+{
+
+    [Headers ("Authorization: Bearer")]
+    public interface IPersonalAccessTokens
+    {
+
+        [Get ("/api/v4/personal_access_tokens/self")]
+        Task<ApiResponse<PersonalAccessToken>> GetSelfAsync(CancellationToken cancellationToken);
+        [Post ("/api/v4/personal_access_tokens/self/rotate")]
+        Task<ApiResponse<PersonalAccessToken>> RotateSelfAsync(CancellationToken cancellationToken);
+
+    }
+}

--- a/Red55.Mattermost.OpenId.Proxy/Extensions/GitLab/User.cs
+++ b/Red55.Mattermost.OpenId.Proxy/Extensions/GitLab/User.cs
@@ -13,7 +13,7 @@ namespace Red55.Mattermost.OpenId.Proxy.Extensions.GitLab
                 // ComputeHash - returns byte array
                 byte[] bytes = SHA256.HashData (Encoding.UTF8.GetBytes (rawData));
 
-                // Convert byte array to a string
+                // Convert byte array to a PersonalAccessToken
                 StringBuilder builder = new StringBuilder ();
                 for (int i = 0; i < bytes.Length; i++)
                 {

--- a/Red55.Mattermost.OpenId.Proxy/GlobalSuppressions.cs
+++ b/Red55.Mattermost.OpenId.Proxy/GlobalSuppressions.cs
@@ -6,3 +6,4 @@
 using System.Diagnostics.CodeAnalysis;
 
 [assembly: SuppressMessage ("Major Code Smell", "S2139:Exceptions should be either logged or rethrown but not both", Justification = "<Pending>", Scope = "member", Target = "~M:Red55.Mattermost.OpenId.Proxy.Transforms.Response.ReplaceInResponseTransform.ApplyAsync(Yarp.ReverseProxy.Transforms.ResponseTransformContext)~System.Threading.Tasks.ValueTask")]
+[assembly: SuppressMessage ("Minor Code Smell", "S6667:Logging in a catch clause should pass the caught exception as a parameter.", Justification = "<Pending>", Scope = "member", Target = "~M:Red55.Mattermost.OpenId.Proxy.Services.PatRotateService.DoWork(System.Threading.CancellationToken)~System.Threading.Tasks.Task")]

--- a/Red55.Mattermost.OpenId.Proxy/Middlewares/HttpClient/HttpRequestOptionsHandler.cs
+++ b/Red55.Mattermost.OpenId.Proxy/Middlewares/HttpClient/HttpRequestOptionsHandler.cs
@@ -1,0 +1,33 @@
+using Red55.Mattermost.OpenId.Proxy.Storage;
+
+namespace Red55.Mattermost.OpenId.Proxy.Middlewares.HttpClient
+{
+    public class HttpRequestOptionsHandler : DelegatingHandler
+    {
+        public HttpRequestOptionsHandler(IPatStore patStore, ILogger<HttpRequestOptionsHandler> logger)
+        {
+            PatStore = EnsureArg.IsNotNull (patStore, nameof (patStore));
+            Log = EnsureArg.IsNotNull (logger, nameof (logger));
+
+        }
+
+
+        public HttpRequestOptionsHandler(IPatStore patStore, ILogger<HttpRequestOptionsHandler> logger,
+            HttpMessageHandler innerHandler) : base (innerHandler)
+        {
+            PatStore = EnsureArg.IsNotNull (patStore, nameof (patStore));
+            Log = EnsureArg.IsNotNull (logger, nameof (logger));
+
+        }
+
+        IPatStore PatStore { get; }
+        ILogger<HttpRequestOptionsHandler> Log { get; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            // Set an option (example key/value)
+            request.Options.Set (new HttpRequestOptionsKey<IPatStore> (nameof (IPatStore)), PatStore);
+            return base.SendAsync (request, cancellationToken);
+        }
+    }
+}

--- a/Red55.Mattermost.OpenId.Proxy/Models/AppConfig.cs
+++ b/Red55.Mattermost.OpenId.Proxy/Models/AppConfig.cs
@@ -4,18 +4,28 @@ using Destructurama.Attributed;
 
 namespace Red55.Mattermost.OpenId.Proxy.Models
 {
+    public record GitlabPat
+    {
+        [Required]
+        [LogMasked]
+        public required string BootstrapToken { get; init; } = string.Empty;
+        [Required]
+        public required string StoreLocation { get; init; } = string.Empty;
+
+        public TimeSpan GracePeriod { get; init; } = TimeSpan.FromDays (1);
+    }
+
     public record GitLabSettings
     {
         public readonly static GitLabSettings Empty = new ()
         {
-            PAT = string.Empty,
+            PAT = new GitlabPat () { StoreLocation = "/home/app/", BootstrapToken = string.Empty },
             Url = new Uri (string.Empty)
         };
         [Required]
         public required Uri Url { get; init; }
         [Required]
-        [LogMasked]
-        public required string PAT { get; init; }
+        public required GitlabPat PAT { get; init; }
     }
     public record OpenIdSettings
     {

--- a/Red55.Mattermost.OpenId.Proxy/Models/Converters/Yaml/DateTimeOffsetConverter.cs
+++ b/Red55.Mattermost.OpenId.Proxy/Models/Converters/Yaml/DateTimeOffsetConverter.cs
@@ -1,0 +1,54 @@
+using System.Globalization;
+
+using YamlDotNet.Core;
+using YamlDotNet.Core.Events;
+using YamlDotNet.Serialization;
+
+public class DateTimeOffsetFormatConverter<T> : IYamlTypeConverter
+{
+    private string Format { get; init; }
+
+    public DateTimeOffsetFormatConverter(string format)
+    {
+        Format = EnsureArg.IsNotNullOrWhiteSpace (format, nameof (format));
+    }
+
+    public bool Accepts(Type type) => type == typeof (T);
+
+    public object ReadYaml(IParser parser, Type type)
+    {
+        var value = parser.Consume<Scalar> ().Value;
+        return type == typeof (DateTimeOffset)
+            ? DateTimeOffset.ParseExact (value, Format, CultureInfo.InvariantCulture)
+            : DateOnly.ParseExact (value, Format, CultureInfo.InvariantCulture);
+    }
+
+    public void WriteYaml(IEmitter emitter, object? value, Type type)
+    {
+        if (value is null)
+        {
+            emitter.Emit (new Scalar ("null"));
+            return;
+        }
+        var o = (T)value!;
+
+        var formattedValue = o switch
+        {
+            DateTimeOffset dto => dto.ToString (Format, CultureInfo.InvariantCulture),
+            DateOnly dto => dto.ToString (Format, CultureInfo.InvariantCulture),
+            _ => throw new InvalidOperationException ($"Unsupported type: {type.FullName}")
+        };
+
+        emitter.Emit (new Scalar (formattedValue));
+    }
+}
+
+public class DateTimeOffsetConverter : DateTimeOffsetFormatConverter<DateTimeOffset>
+{
+    public DateTimeOffsetConverter() : base ("yyyy-MM-ddTHH:mm:ss.fffZ") { }
+}
+
+public class DateOnlyConverter : DateTimeOffsetFormatConverter<DateOnly>
+{
+    public DateOnlyConverter() : base ("yyyy-MM-dd") { }
+}

--- a/Red55.Mattermost.OpenId.Proxy/Models/Gitlab/PersonalAccessToken.cs
+++ b/Red55.Mattermost.OpenId.Proxy/Models/Gitlab/PersonalAccessToken.cs
@@ -1,0 +1,20 @@
+﻿using Destructurama.Attributed;
+
+namespace Red55.Mattermost.OpenId.Proxy.Models.Gitlab
+{
+    public record PersonalAccessToken
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public bool Revoked { get; set; }
+        public DateTimeOffset CreatedAt { get; set; }
+        public string Description { get; set; } = string.Empty;
+        public string[] Scopes { get; set; } = [];
+        public int UserId { get; set; }
+        public DateTimeOffset LastUsedAt { get; set; }
+        public DateOnly ExpiresAt { get; set; }
+        public bool Active { get; set; }
+        [LogMasked]
+        public string Token { get; set; } = string.Empty;
+    }
+}

--- a/Red55.Mattermost.OpenId.Proxy/Red55.Mattermost.OpenId.Proxy.csproj
+++ b/Red55.Mattermost.OpenId.Proxy/Red55.Mattermost.OpenId.Proxy.csproj
@@ -53,4 +53,8 @@
     <Using Include="EnsureThat" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Folder Include="Models\Converters\Yaml\" />
+  </ItemGroup>
+
 </Project>

--- a/Red55.Mattermost.OpenId.Proxy/Services/PatRotateService.cs
+++ b/Red55.Mattermost.OpenId.Proxy/Services/PatRotateService.cs
@@ -1,0 +1,106 @@
+﻿using Microsoft.Extensions.Options;
+
+using Red55.Mattermost.OpenId.Proxy.Api.Gitlab;
+using Red55.Mattermost.OpenId.Proxy.Models;
+using Red55.Mattermost.OpenId.Proxy.Storage;
+
+namespace Red55.Mattermost.OpenId.Proxy.Services
+{
+    public class PatRotateService(
+        IPersonalAccessTokens patApi,
+        IPatStore patStore,
+        IOptions<AppConfig> config,
+        IHostApplicationLifetime applicationLifetime,
+        ILogger<PatRotateService> logger) : IHostedService
+    {
+        AppConfig Config { get; } = EnsureArg.IsNotNull (EnsureArg.IsNotNull (config, nameof (config)).Value,
+            nameof (config.Value));
+        ILogger Log { get; } = EnsureArg.IsNotNull (logger, nameof (logger));
+        IPersonalAccessTokens PatApi { get; } = EnsureArg.IsNotNull (patApi, nameof (patApi));
+        IPatStore PatStore { get; } = EnsureArg.IsNotNull (patStore, nameof (patStore));
+        IHostApplicationLifetime ApplicationLifetime { get; } =
+            EnsureArg.IsNotNull (applicationLifetime, nameof (applicationLifetime));
+        Task? _myWork;
+        private CancellationTokenSource? _cts;
+
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            Log.LogInformation ("Starting PAT rotation service");
+            _cts = CancellationTokenSource.CreateLinkedTokenSource (cancellationToken);
+            _myWork = Task.Run (() => DoWork (_cts.Token), _cts.Token);
+            return Task.CompletedTask;
+        }
+
+        private async Task DoWork(CancellationToken cancellationToken)
+        {
+            try
+            {
+                while (!cancellationToken.IsCancellationRequested)
+                {
+                    var apiResponse = await PatApi.GetSelfAsync (cancellationToken);
+                    if (!apiResponse.IsSuccessStatusCode || apiResponse.Content is null)
+                    {
+                        Log.LogWarning ("Get Self Info for PAT failed {Status}. Will try again later.",
+                            apiResponse.StatusCode);
+                        await Task.Delay (10_000, cancellationToken);
+                        continue;
+                    }
+
+                    var token = await PatStore.GetTokenAsync (cancellationToken);
+                    await PatStore.UpdateAsync (apiResponse.Content with { Token = token }, cancellationToken);
+
+                    Log.LogInformation ("PAT retrieved successfully: {Id}, {Name}, {ExpiresAt}",
+                        apiResponse.Content.Id, apiResponse.Content.Name, apiResponse.Content.ExpiresAt);
+                    var nextRotation = apiResponse.Content.ExpiresAt.ToDateTime (TimeOnly.MinValue)
+                        - DateTimeOffset.UtcNow - Config.GitLab.PAT.GracePeriod;
+
+                    Log.LogDebug ("Sleeping until next PAT rotation: {GracePeriod}, {NextRotation}",
+                        Config.GitLab.PAT.GracePeriod, nextRotation);
+
+                    await SafeDelay (nextRotation, cancellationToken);
+
+                    apiResponse = await PatApi.RotateSelfAsync (cancellationToken);
+                    if (!apiResponse.IsSuccessStatusCode || apiResponse.Content is null)
+                    {
+                        Log.LogError ("Failed to rotate PAT: {StatusCode} - {ReasonPhrase}",
+                            apiResponse.StatusCode, apiResponse.ReasonPhrase);
+                    }
+                    else
+                    {
+                        await PatStore.UpdateAsync (apiResponse.Content, cancellationToken);
+                        Log.LogInformation ("PAT rotated successfully: {Id}, {Name}, {ExpiresAt}",
+                            apiResponse.Content.Id, apiResponse.Content.Name, apiResponse.Content.ExpiresAt);
+                    }
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                Log.LogInformation ("PAT rotation service was cancelled");
+            }
+            catch (Exception e)
+            {
+                Log.LogError (e, "An error occurred in the PAT rotation service");
+                ApplicationLifetime.StopApplication (); // Stop the application if an unhandled exception occurs
+                throw;
+            }
+
+        }
+        public static async Task SafeDelay(TimeSpan totalDelay, CancellationToken cancellationToken)
+        {
+            TimeSpan maxDelay = TimeSpan.FromMilliseconds (int.MaxValue);
+            while (totalDelay > TimeSpan.Zero)
+            {
+                var delay = totalDelay > maxDelay ? maxDelay : totalDelay;
+                await Task.Delay (delay, cancellationToken);
+                totalDelay -= delay;
+            }
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken)
+        {
+            Log.LogInformation ("Stopping PAT rotation service");
+            _cts?.Cancel ();
+            return _myWork ?? Task.CompletedTask;
+        }
+    }
+}

--- a/Red55.Mattermost.OpenId.Proxy/Storage/PatStore.cs
+++ b/Red55.Mattermost.OpenId.Proxy/Storage/PatStore.cs
@@ -37,7 +37,7 @@ namespace Red55.Mattermost.OpenId.Proxy.Storage
             try
             {
                 cancellationToken.ThrowIfCancellationRequested ();
-                if (_pat is null && File.Exists (StroreFileName))
+                if (_pat is null && File.Exists (StoreFileName))
                 {
                     var deserializer = new DeserializerBuilder ()
                         .WithNamingConvention (CamelCaseNamingConvention.Instance)
@@ -45,7 +45,7 @@ namespace Red55.Mattermost.OpenId.Proxy.Storage
                         .WithTypeConverter (new DateOnlyConverter ())
                         .Build ();
 
-                    using var reader = new StreamReader (StroreFileName);
+                    using var reader = new StreamReader (StoreFileName);
                     _pat = deserializer.Deserialize<PersonalAccessToken> (reader);
                 }
                 return ValueTask.FromResult (_pat is null ? Config.GitLab.PAT.BootstrapToken : _pat.Token);
@@ -67,7 +67,7 @@ namespace Red55.Mattermost.OpenId.Proxy.Storage
 
                 Directory.CreateDirectory (Config.GitLab.PAT.StoreLocation);
 
-                using var f = File.OpenWrite (StroreFileName);
+                using var f = File.OpenWrite (StoreFileName);
                 using var writer = new StreamWriter (f, System.Text.Encoding.UTF8);
 
                 var serializer = new SerializerBuilder ()

--- a/Red55.Mattermost.OpenId.Proxy/Storage/PatStore.cs
+++ b/Red55.Mattermost.OpenId.Proxy/Storage/PatStore.cs
@@ -23,7 +23,7 @@ namespace Red55.Mattermost.OpenId.Proxy.Storage
         readonly ReaderWriterLockSlim _lock = new ();
         PersonalAccessToken? _pat;
 
-        string StroreFileName
+        string StoreFileName
         {
             get
             {

--- a/Red55.Mattermost.OpenId.Proxy/Storage/PatStore.cs
+++ b/Red55.Mattermost.OpenId.Proxy/Storage/PatStore.cs
@@ -1,0 +1,93 @@
+﻿using Microsoft.Extensions.Options;
+
+using Red55.Mattermost.OpenId.Proxy.Models;
+using Red55.Mattermost.OpenId.Proxy.Models.Gitlab;
+
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace Red55.Mattermost.OpenId.Proxy.Storage
+{
+    public interface IPatStore
+    {
+        ValueTask<string> GetTokenAsync(CancellationToken cancellationToken);
+        ValueTask UpdateAsync(PersonalAccessToken pat, CancellationToken cancellationToken);
+    }
+    public class PatStore(ILogger<PatStore> logger, IOptions<AppConfig> config) : IPatStore
+    {
+        const string PAT_FILE_NAME = "pat.yml";
+        ILogger Log { get; } = EnsureArg.IsNotNull (logger, nameof (logger));
+        AppConfig Config { get; } = EnsureArg.IsNotNull (EnsureArg.IsNotNull (config, nameof (config)).Value,
+            nameof (config.Value));
+
+        readonly ReaderWriterLockSlim _lock = new ();
+        PersonalAccessToken? _pat;
+
+        string StroreFileName
+        {
+            get
+            {
+                return Path.Join (Config.GitLab.PAT.StoreLocation, PAT_FILE_NAME);
+            }
+        }
+
+        public ValueTask<string> GetTokenAsync(CancellationToken cancellationToken)
+        {
+            _lock.EnterReadLock ();
+            try
+            {
+                cancellationToken.ThrowIfCancellationRequested ();
+                if (_pat is null && File.Exists (StroreFileName))
+                {
+                    var deserializer = new DeserializerBuilder ()
+                        .WithNamingConvention (CamelCaseNamingConvention.Instance)
+                        .WithTypeConverter (new DateTimeOffsetConverter ())
+                        .WithTypeConverter (new DateOnlyConverter ())
+                        .Build ();
+
+                    using var reader = new StreamReader (StroreFileName);
+                    _pat = deserializer.Deserialize<PersonalAccessToken> (reader);
+                }
+                return ValueTask.FromResult (_pat is null ? Config.GitLab.PAT.BootstrapToken : _pat.Token);
+            }
+            finally
+            {
+                _lock.ExitReadLock ();
+            }
+        }
+
+        public async ValueTask UpdateAsync(PersonalAccessToken pat, CancellationToken cancellationToken)
+        {
+            _lock.EnterWriteLock ();
+            try
+            {
+                _pat = EnsureArg.IsNotNull (pat, nameof (pat));
+
+                cancellationToken.ThrowIfCancellationRequested ();
+
+                Directory.CreateDirectory (Config.GitLab.PAT.StoreLocation);
+
+                using var f = File.OpenWrite (StroreFileName);
+                using var writer = new StreamWriter (f, System.Text.Encoding.UTF8);
+
+                var serializer = new SerializerBuilder ()
+                    .WithNamingConvention (CamelCaseNamingConvention.Instance)
+                    .WithTypeConverter (new DateTimeOffsetConverter ())
+                    .WithTypeConverter (new DateOnlyConverter ())
+                    .Build ();
+
+                cancellationToken.ThrowIfCancellationRequested ();
+                await writer.WriteAsync (serializer.Serialize (pat));
+            }
+            catch (Exception e)
+            {
+                Log.LogError (e, "Error while saving PAT");
+                throw;
+            }
+            finally
+            {
+                _lock.ExitWriteLock ();
+            }
+        }
+    }
+}

--- a/Red55.Mattermost.OpenId.Proxy/appsettings.Development.yml
+++ b/Red55.Mattermost.OpenId.Proxy/appsettings.Development.yml
@@ -56,4 +56,7 @@ AppConfig:
     AppSecret: "gloas-1c8b6d60a86e8c7b054a0d443bc8520821f8a88d0ac3579e020f7bfa6a84b279"
   GitLab:
     Url: "http://gitlab.localhost"
-    PAT: "glpat-tcHWEY7BL3NrMR5yZp9S"
+    PAT:
+      BootstrapToken: "glpat-tcHWEY7BL3NrMR5yZp9S"
+      StoreLocation: "/home/app/.gitlab/pat"
+

--- a/Red55.Mattermost.OpenId.Proxy/appsettings.yml
+++ b/Red55.Mattermost.OpenId.Proxy/appsettings.yml
@@ -81,6 +81,8 @@ AppConfig:
     AppSecret: ""
   GitLab:
     Url: "http://gitlab.apps.yunqi.studio"
-    PAT: ""
+    PAT:
+      BootstrapToken: "glpat-t"
+      StoreLocation: "/home/app/.gitlab/pat"
 
   


### PR DESCRIPTION
feat(gitlab): enhance PAT management and configuration. closes #1

- Update README.md to specify required scopes for Personal Access Token.
- Add IPersonalAccessTokens interface for GitLab API interactions.
- Introduce HttpRequestOptionsHandler for HTTP request options.
- Create GitlabPat record for improved PAT configuration.
- Add DateTimeOffset and DateOnly converters for YAML serialization.
- Update Program.cs to register new services for PAT management.
- Add PatRotateService for periodic PAT rotation logic.