### PR TITLE
chore(deps): update package versions and add health checks. Closes #2.

### DIFF
--- a/Red55.Mattermost.OpenId.Proxy/Api/Gitlab/HealthChecks.cs
+++ b/Red55.Mattermost.OpenId.Proxy/Api/Gitlab/HealthChecks.cs
@@ -1,0 +1,23 @@
+﻿using Refit;
+
+namespace Red55.Mattermost.OpenId.Proxy.Api.Gitlab
+{
+    [Headers ("Authorization: Bearer")]
+    public interface IGitlabHealthChecks
+    {
+        enum Checks
+        {
+            None,
+            All = 1
+        }
+
+        [Get ("/-/health")]
+        Task<ApiResponse<string>> GetHealthAsync(CancellationToken cancellationToken);
+
+        [Get ("/-/liveness")]
+        Task<ApiResponse<string>> GetLivenessAsync(CancellationToken cancellationToken);
+
+        [Get ("/-/readiness")]
+        Task<ApiResponse<string>> GetReadinessAsync(CancellationToken cancellationToken, Checks all = Checks.All);
+    }
+}

--- a/Red55.Mattermost.OpenId.Proxy/Directory.Packages.props
+++ b/Red55.Mattermost.OpenId.Proxy/Directory.Packages.props
@@ -9,11 +9,12 @@
   <ItemGroup>
     <PackageVersion Include="Destructurama.Attributed" Version="5.1.0" />
     <PackageVersion Include="Ensure.That" Version="10.1.0" />
-    <PackageVersion Include="Generator.Equals" Version="3.0.0" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.5" />
+    <PackageVersion Include="Generator.Equals" Version="3.2.0" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="9.0.7" />
     <PackageVersion Include="Microsoft.Identity.Web" Version="2.17.5" />
     <PackageVersion Include="Microsoft.Identity.Web.UI" Version="2.16.0" />
-    <PackageVersion Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.2" />
+    <PackageVersion Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.22.1" />
     <PackageVersion Include="Microsoft.VisualStudio.Threading" Version="17.9.28" />
     <PackageVersion Include="MinVer" Version="6.0.0" />
     <PackageVersion Include="NetEscapades.Configuration.Yaml" Version="3.1.0" />
@@ -26,7 +27,7 @@
     <PackageVersion Include="Refit.HttpClientFactory" Version="8.0.0" />
     <PackageVersion Include="Serilog" Version="4.3.0" />
     <PackageVersion Include="Serilog.AspNetCore" Version="9.0.0" />
-    <PackageVersion Include="Serilog.Enrichers.ClientInfo" Version="2.1.2" />
+    <PackageVersion Include="Serilog.Enrichers.ClientInfo" Version="2.2.0" />
     <PackageVersion Include="Serilog.Enrichers.Process" Version="3.0.0" />
     <PackageVersion Include="Serilog.Enrichers.Span" Version="3.1.0" />
     <PackageVersion Include="Serilog.Enrichers.Thread" Version="4.0.0" />
@@ -34,10 +35,10 @@
     <PackageVersion Include="Serilog.Exceptions.Refit" Version="8.4.0" />
     <PackageVersion Include="Serilog.Expressions" Version="5.0.0" />
     <PackageVersion Include="Serilog.Extensions.Hosting" Version="9.0.0" />
-    <PackageVersion Include="Serilog.Extensions.Logging" Version="9.0.1" />
+    <PackageVersion Include="Serilog.Extensions.Logging" Version="9.0.2" />
     <PackageVersion Include="Serilog.Settings.Configuration" Version="9.0.0" />
     <PackageVersion Include="Serilog.Sinks.Console" Version="6.0.0" />
-    <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.11.0" />
+    <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.12.1" />
     <PackageVersion Include="Yarp.ReverseProxy" Version="2.3.0" />
   </ItemGroup>
 </Project>

--- a/Red55.Mattermost.OpenId.Proxy/Extensions/Uri.cs
+++ b/Red55.Mattermost.OpenId.Proxy/Extensions/Uri.cs
@@ -1,0 +1,12 @@
+﻿using Red55.Mattermost.OpenId.Proxy.Models;
+
+namespace Red55.Mattermost.OpenId.Proxy.Extensions
+{
+    public static class UriExtensions
+    {
+        public static bool IsNullOrEmpty(this Uri? uri)
+        {
+            return uri is null || AppConfig.EmptyUri == uri;
+        }
+    }
+}

--- a/Red55.Mattermost.OpenId.Proxy/Models/AppConfig.cs
+++ b/Red55.Mattermost.OpenId.Proxy/Models/AppConfig.cs
@@ -2,9 +2,12 @@
 
 using Destructurama.Attributed;
 
+using Generator.Equals;
+
 namespace Red55.Mattermost.OpenId.Proxy.Models
 {
-    public record GitlabPat
+    [Equatable]
+    public partial record GitlabPat
     {
         [Required]
         [LogMasked]
@@ -14,26 +17,40 @@ namespace Red55.Mattermost.OpenId.Proxy.Models
 
         public TimeSpan GracePeriod { get; init; } = TimeSpan.FromDays (1);
     }
-
-    public record GitLabSettings
+    [Equatable]
+    public partial record GitLabSettings
     {
         public readonly static GitLabSettings Empty = new ()
         {
             PAT = new GitlabPat () { StoreLocation = "/home/app/", BootstrapToken = string.Empty },
-            Url = new Uri (string.Empty)
+            Url = AppConfig.EmptyUri
         };
         [Required]
         public required Uri Url { get; init; }
         [Required]
         public required GitlabPat PAT { get; init; }
     }
-    public record OpenIdSettings
+    [Equatable]
+    public partial record OpenIdHealthChecks
+    {
+        public readonly static OpenIdHealthChecks Empty;
+
+        public Uri LivenessUrl { get; init; } = AppConfig.EmptyUri;
+
+        [Required]
+        public required Uri ReadinessUrl { get; init; }
+
+        public required bool DangerousAcceptAnyServerCertificate { get; init; } = false;
+    }
+    [Equatable]
+    public partial record OpenIdSettings
     {
         public readonly static OpenIdSettings Empty = new ()
         {
             AppId = string.Empty,
             AppSecret = string.Empty,
-            Url = new Uri (string.Empty)
+            Url = AppConfig.EmptyUri,
+            HealthChecks = OpenIdHealthChecks.Empty
         };
 
         [Required]
@@ -43,11 +60,14 @@ namespace Red55.Mattermost.OpenId.Proxy.Models
         [Required]
         [LogMasked]
         public required string AppSecret { get; init; }
-    }
 
-    public class AppConfig
+        public OpenIdHealthChecks HealthChecks { get; init; } = OpenIdHealthChecks.Empty;
+    }
+    [Equatable]
+    public sealed partial class AppConfig
     {
         public static readonly string SectionName = nameof (AppConfig);
+        public static readonly Uri EmptyUri = new ("about:blank");
 
         [Required]
         public required OpenIdSettings OpenId { get; init; }

--- a/Red55.Mattermost.OpenId.Proxy/Program.cs
+++ b/Red55.Mattermost.OpenId.Proxy/Program.cs
@@ -128,6 +128,21 @@ try
             o.SerializerOptions.DictionaryKeyPolicy = System.Text.Json.JsonNamingPolicy.SnakeCaseLower;
         });
 
+    _ = builder.Services
+        .AddHttpClient ("OpenIdApiChecks", c =>
+        {
+        }).ConfigurePrimaryHttpMessageHandler (() =>
+        {
+            var r = new HttpClientHandler ();
+
+            if (appConfig.OpenId.HealthChecks != OpenIdHealthChecks.Empty &&
+                appConfig.OpenId.HealthChecks.DangerousAcceptAnyServerCertificate)
+            {
+                r.ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator;
+            }
+
+            return r;
+        });
     // Register the custom health check
     var checks = builder.Services
         .AddHealthChecks ();

--- a/Red55.Mattermost.OpenId.Proxy/Program.cs
+++ b/Red55.Mattermost.OpenId.Proxy/Program.cs
@@ -2,13 +2,16 @@ using System.Reflection;
 
 using Destructurama;
 
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
 
 using Red55.Mattermost.OpenId.Proxy.Api.Gitlab;
+using Red55.Mattermost.OpenId.Proxy.Extensions;
 using Red55.Mattermost.OpenId.Proxy.Middlewares.HttpClient;
 using Red55.Mattermost.OpenId.Proxy.Middlewares.Kestrel;
 using Red55.Mattermost.OpenId.Proxy.Models;
 using Red55.Mattermost.OpenId.Proxy.Services;
+using Red55.Mattermost.OpenId.Proxy.Services.HealthChecks;
 using Red55.Mattermost.OpenId.Proxy.Storage;
 using Red55.Mattermost.OpenId.Proxy.Transforms;
 
@@ -19,6 +22,7 @@ using Serilog.Enrichers.Span;
 using Serilog.Exceptions;
 using Serilog.Exceptions.Core;
 using Serilog.Exceptions.Refit.Destructurers;
+using Serilog.Templates;
 
 var builder = WebApplication.CreateBuilder (args);
 
@@ -30,7 +34,7 @@ Log.Logger = new LoggerConfiguration ()
         .WithDefaultDestructurers ()
         .WithDestructurers ([new ApiExceptionDestructurer (destructureCommonExceptionProperties: false)]))
     .MinimumLevel.Debug ()
-    .WriteTo.Console (outputTemplate: "[{Timestamp:HH:mm:ss} {Coalesce(CorrelationId, '0000000000000:00000000')} {Level:u3}] {Message:lj}{NewLine}{Exception}")
+    .WriteTo.Console (new ExpressionTemplate ("[{@t:yyyy-MM-ddTHH:mm:ss} {Coalesce(CorrelationId, '0000000000000:00000000')} {@l:u3}] {@m}\n{@x}"))
     .CreateBootstrapLogger ();
 
 try
@@ -99,6 +103,17 @@ try
         .AddRefitClient<IPersonalAccessTokens> (services => refitSettings)
         .ConfigureHttpClient (c => c.BaseAddress = appConfig.GitLab.Url)
         .ConfigureAdditionalHttpMessageHandlers ((handlers, services) => handlers.Add (services.GetRequiredService<HttpRequestOptionsHandler> ()));
+    _ = builder.Services
+          .AddRefitClient<IGitlabHealthChecks> (services => refitSettings)
+          .ConfigureHttpClient (c => c.BaseAddress = appConfig.GitLab.Url)
+          .ConfigureAdditionalHttpMessageHandlers ((handlers, services) => handlers.Add (services.GetRequiredService<HttpRequestOptionsHandler> ()));
+
+
+    // Register the named HttpClient for GitLab API
+    _ = builder.Services.AddHttpClient ("GitLabApi", c =>
+    {
+        c.BaseAddress = appConfig.GitLab.Url;
+    });
 
     _ = builder.Services
         .AddControllers ()
@@ -113,18 +128,49 @@ try
             o.SerializerOptions.DictionaryKeyPolicy = System.Text.Json.JsonNamingPolicy.SnakeCaseLower;
         });
 
+    // Register the custom health check
+    var checks = builder.Services
+        .AddHealthChecks ();
+    _ = checks
+        .AddCheck<GitLabApiReadinessCheck> ("gitlab_readiness", tags: ["ready"])
+        .AddCheck<GitLabApiLivenessCheck> ("gitlab_liveness", tags: ["alive"]);
+
+    if (appConfig.OpenId.HealthChecks != OpenIdHealthChecks.Empty)
+    {
+        if (!appConfig.OpenId.HealthChecks.LivenessUrl.IsNullOrEmpty ())
+        {
+            _ = checks.AddCheck<OpenIdApiLivenessCheck> ("open_id_liveness", tags: ["alive"]);
+        }
+        if (!appConfig.OpenId.HealthChecks.ReadinessUrl.IsNullOrEmpty ())
+        {
+            _ = checks.AddCheck<OpenIdApiReadinessCheck> ("open_id_readiness", tags: ["ready"]);
+        }
+    }
+    else
+    {
+        Log.Logger.Warning ("OpenID Health Checks are not configured. Skipping OpenID health checks registration.");
+    }
+
     _ = builder.Host.UseSerilog ((context, services, configuration) => configuration
-                         .ReadFrom.Configuration (context.Configuration)
-                         .ReadFrom.Services (services)
-                         .Enrich.FromLogContext ()
-                         .Enrich.WithCorrelationId ()
-                         .Enrich.WithSpan ()
-                         .Destructure.UsingAttributes ());
+        .ReadFrom.Configuration (context.Configuration)
+        .ReadFrom.Services (services)
+        .Enrich.FromLogContext ()
+        .Enrich.WithCorrelationId ()
+        .Enrich.WithSpan ()
+        .Destructure.UsingAttributes ());
 
     var app = builder.Build ();
 
-
     _ = app.UseMiddleware<CorrelationIdMiddleware> ();
+
+    _ = app.MapHealthChecks ("/healthz/ready", new HealthCheckOptions
+    {
+        Predicate = check => check.Tags.Contains ("ready")
+    });
+    _ = app.MapHealthChecks ("/healthz/live", new HealthCheckOptions
+    {
+        Predicate = check => check.Tags.Contains ("alive")
+    });
 
     _ = app.MapControllers ();
 

--- a/Red55.Mattermost.OpenId.Proxy/Red55.Mattermost.OpenId.Proxy.csproj
+++ b/Red55.Mattermost.OpenId.Proxy/Red55.Mattermost.OpenId.Proxy.csproj
@@ -23,6 +23,7 @@
   <ItemGroup>
     <PackageReference Include="Destructurama.Attributed" />
     <PackageReference Include="Ensure.That" />
+    <PackageReference Include="Generator.Equals" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" />
     <PackageReference Include="MinVer">

--- a/Red55.Mattermost.OpenId.Proxy/Services/HealthChecks/GitLabApiCheck.cs
+++ b/Red55.Mattermost.OpenId.Proxy/Services/HealthChecks/GitLabApiCheck.cs
@@ -1,0 +1,55 @@
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+using Red55.Mattermost.OpenId.Proxy.Api.Gitlab;
+
+namespace Red55.Mattermost.OpenId.Proxy.Services.HealthChecks;
+public class GitLabApiReadinessCheck(IGitlabHealthChecks gitlabHealth,
+    ILogger<GitLabApiReadinessCheck> log) : IHealthCheck
+
+{
+    public async Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var response = await gitlabHealth.GetReadinessAsync (cancellationToken);
+            if (response.IsSuccessStatusCode)
+            {
+                return HealthCheckResult.Healthy ("GitLab API is ready.");
+            }
+            log.LogWarning ("GitLab API readiness check returned status code {StatusCode}.", response.StatusCode);
+            return HealthCheckResult.Unhealthy ($"GitLab API returned status code {response.StatusCode}.");
+        }
+        catch (Exception ex)
+        {
+            log.LogError (ex, "GitLab API readiness check failed.");
+            return HealthCheckResult.Unhealthy ("GitLab API readiness check failed.", ex);
+        }
+    }
+}
+
+public class GitLabApiLivenessCheck(IGitlabHealthChecks gitlabHealth,
+    ILogger<GitLabApiLivenessCheck> log) : IHealthCheck
+{
+    public async Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var response = await gitlabHealth.GetLivenessAsync (cancellationToken);
+            if (response.IsSuccessStatusCode)
+            {
+                return HealthCheckResult.Healthy ("GitLab API is alive.");
+            }
+            log.LogWarning ("GitLab API liveness check returned status code {StatusCode}.", response.StatusCode);
+            return HealthCheckResult.Unhealthy ($"GitLab API returned status code {response.StatusCode}.");
+        }
+        catch (Exception ex)
+        {
+            log.LogError (ex, "GitLab API liveness check failed.");
+            return HealthCheckResult.Unhealthy ("GitLab API liveness check failed.", ex);
+        }
+    }
+}

--- a/Red55.Mattermost.OpenId.Proxy/Services/HealthChecks/OpenIdApiChecks.cs
+++ b/Red55.Mattermost.OpenId.Proxy/Services/HealthChecks/OpenIdApiChecks.cs
@@ -7,16 +7,14 @@ using Red55.Mattermost.OpenId.Proxy.Models;
 namespace Red55.Mattermost.OpenId.Proxy.Services.HealthChecks;
 
 public class OpenIdApiReadinessCheck(IOptions<AppConfig> config,
-    ILogger<OpenIdApiReadinessCheck> log) : IHealthCheck
+    ILogger<OpenIdApiReadinessCheck> log,
+    IHttpClientFactory httpClientFactory) : IHealthCheck
 {
     protected AppConfig Config { get; } = config.Value;
+    private readonly IHttpClientFactory _httpClientFactory = httpClientFactory;
     public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
     {
-        var handler = new HttpClientHandler
-        {
-            ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator,
-        };
-        HttpClient http = Config.OpenId.HealthChecks.DangerousAcceptAnyServerCertificate ? new (handler) : new ();
+        var http = _httpClientFactory.CreateClient("OpenIdApiReadiness");
 
         try
         {

--- a/Red55.Mattermost.OpenId.Proxy/Services/HealthChecks/OpenIdApiChecks.cs
+++ b/Red55.Mattermost.OpenId.Proxy/Services/HealthChecks/OpenIdApiChecks.cs
@@ -1,0 +1,67 @@
+﻿
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
+
+using Red55.Mattermost.OpenId.Proxy.Models;
+
+namespace Red55.Mattermost.OpenId.Proxy.Services.HealthChecks;
+
+public class OpenIdApiReadinessCheck(IOptions<AppConfig> config,
+    ILogger<OpenIdApiReadinessCheck> log) : IHealthCheck
+{
+    protected AppConfig Config { get; } = config.Value;
+    public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+    {
+        var handler = new HttpClientHandler
+        {
+            ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator,
+        };
+        HttpClient http = Config.OpenId.HealthChecks.DangerousAcceptAnyServerCertificate ? new (handler) : new ();
+
+        try
+        {
+            var r = await http.GetAsync (Config.OpenId.HealthChecks.ReadinessUrl, cancellationToken);
+            if (r.IsSuccessStatusCode)
+            {
+                return HealthCheckResult.Healthy ("OpenId API is ready.");
+            }
+            log.LogWarning ("OpenId API readiness check returned status code {StatusCode}.", r.StatusCode);
+            return HealthCheckResult.Unhealthy ($"OpenId API returned status code {r.StatusCode}.");
+        }
+        catch (Exception ex)
+        {
+            log.LogError (ex, "OpenId API readiness check failed.");
+            return HealthCheckResult.Unhealthy ("OpenId API readiness check failed.", ex);
+        }
+    }
+}
+
+
+public class OpenIdApiLivenessCheck(IOptions<AppConfig> config,
+    ILogger<OpenIdApiLivenessCheck> log) : IHealthCheck
+{
+    protected AppConfig Config { get; } = config.Value;
+    public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+    {
+        var handler = new HttpClientHandler
+        {
+            ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator,
+        };
+        HttpClient http = Config.OpenId.HealthChecks.DangerousAcceptAnyServerCertificate ? new (handler) : new ();
+        try
+        {
+            var r = await http.GetAsync (Config.OpenId.HealthChecks.LivenessUrl, cancellationToken);
+            if (r.IsSuccessStatusCode)
+            {
+                return HealthCheckResult.Healthy ("OpenId API is alive.");
+            }
+            log.LogWarning ("OpenId API liveness check returned status code {StatusCode}.", r.StatusCode);
+            return HealthCheckResult.Unhealthy ($"OpenId API returned status code {r.StatusCode}.");
+        }
+        catch (Exception ex)
+        {
+            log.LogError (ex, "OpenId API liveness check failed.");
+            return HealthCheckResult.Unhealthy ("OpenId API Liveness check failed.", ex);
+        }
+    }
+}

--- a/Red55.Mattermost.OpenId.Proxy/Services/HealthChecks/OpenIdApiChecks.cs
+++ b/Red55.Mattermost.OpenId.Proxy/Services/HealthChecks/OpenIdApiChecks.cs
@@ -14,7 +14,7 @@ public class OpenIdApiReadinessCheck(IOptions<AppConfig> config,
     private readonly IHttpClientFactory _httpClientFactory = httpClientFactory;
     public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
     {
-        var http = _httpClientFactory.CreateClient("OpenIdApiReadiness");
+        var http = _httpClientFactory.CreateClient ("OpenIdApiChecks");
 
         try
         {
@@ -36,16 +36,14 @@ public class OpenIdApiReadinessCheck(IOptions<AppConfig> config,
 
 
 public class OpenIdApiLivenessCheck(IOptions<AppConfig> config,
-    ILogger<OpenIdApiLivenessCheck> log) : IHealthCheck
+    ILogger<OpenIdApiLivenessCheck> log,
+    IHttpClientFactory httpClientFactory) : IHealthCheck
 {
     protected AppConfig Config { get; } = config.Value;
+    private readonly IHttpClientFactory _httpClientFactory = httpClientFactory;
     public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
     {
-        var handler = new HttpClientHandler
-        {
-            ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator,
-        };
-        HttpClient http = Config.OpenId.HealthChecks.DangerousAcceptAnyServerCertificate ? new (handler) : new ();
+        var http = _httpClientFactory.CreateClient ("OpenIdApiChecks");
         try
         {
             var r = await http.GetAsync (Config.OpenId.HealthChecks.LivenessUrl, cancellationToken);

--- a/Red55.Mattermost.OpenId.Proxy/appsettings.Development.yml
+++ b/Red55.Mattermost.OpenId.Proxy/appsettings.Development.yml
@@ -54,10 +54,10 @@ AppConfig:
     Url: "http://kc.localhost"
     AppId: "e1bd1f68329950a67a9a7a2b11d5f8fd8799ec3ea2f314d7b4aa90961d61b04a"
     AppSecret: "gloas-1c8b6d60a86e8c7b054a0d443bc8520821f8a88d0ac3579e020f7bfa6a84b279"
-#    HealthChecks:
-#      ReadinessUrl: "https://kc:9000/health/ready"
-#      LivenessUrl: "https://kc:9000/health/live"
-#      DangerousAcceptAnyServerCertificate: true
+    HealthChecks:
+      ReadinessUrl: "https://kc:9000/health/ready"
+      LivenessUrl: "https://kc:9000/health/live"
+      DangerousAcceptAnyServerCertificate: true
   GitLab:
     Url: "http://gitlab.localhost"
     PAT:

--- a/Red55.Mattermost.OpenId.Proxy/appsettings.Development.yml
+++ b/Red55.Mattermost.OpenId.Proxy/appsettings.Development.yml
@@ -54,6 +54,10 @@ AppConfig:
     Url: "http://kc.localhost"
     AppId: "e1bd1f68329950a67a9a7a2b11d5f8fd8799ec3ea2f314d7b4aa90961d61b04a"
     AppSecret: "gloas-1c8b6d60a86e8c7b054a0d443bc8520821f8a88d0ac3579e020f7bfa6a84b279"
+#    HealthChecks:
+#      ReadinessUrl: "https://kc:9000/health/ready"
+#      LivenessUrl: "https://kc:9000/health/live"
+#      DangerousAcceptAnyServerCertificate: true
   GitLab:
     Url: "http://gitlab.localhost"
     PAT:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,13 @@ services:
     build:
       context: .
       dockerfile: Red55.Mattermost.OpenId.Proxy/Dockerfile
+#    healthcheck:
+#      test: ["CMD", "curl", "--head", "-fsSk", "http://localhost:8080/health/ready"]
+#      interval: 1m
+#      timeout: 5s
+#      retries: 15
+#      start_interval: 45s
+#      start_period: 5s
     labels:
       traefik.enable: true
       traefik.http.routers.gl-proxy.entrypoints: http
@@ -71,6 +78,10 @@ services:
         condition: service_healthy
       gitlab:
         condition: service_healthy
+      mm:
+        condition: service_healthy
+      red55.mattermost.openid.proxy:
+        condition: service_started
     ports:
       - 80:80
       - 8080:8080

--- a/docker/gitlab/gitlab.rb
+++ b/docker/gitlab/gitlab.rb
@@ -272,7 +272,7 @@ gitlab_rails['smtp_enable'] = false
 
 ### Monitoring settings
 ###! IP whitelist controlling access to monitoring endpoints
-# gitlab_rails['monitoring_whitelist'] = ['127.0.0.0/8', '::1/128']
+gitlab_rails['monitoring_whitelist'] = ['0.0.0.0/0', '::1/128']
 
 ### Shutdown settings
 ###! Defines an interval to block healthcheck,

--- a/docker/keycloak/Dockerfile
+++ b/docker/keycloak/Dockerfile
@@ -15,7 +15,7 @@ RUN /opt/keycloak/bin/kc.sh build
 
 FROM registry.access.redhat.com/ubi9 AS ubi-micro-build
 RUN mkdir -p /mnt/rootfs
-RUN dnf install --installroot /mnt/rootfs curl --releasever 9 --setopt install_weak_deps=false --nodocs -y && \
+RUN dnf install --installroot /mnt/rootfs curl iproute --releasever 9 --setopt install_weak_deps=false --nodocs -y && \
     dnf --installroot /mnt/rootfs clean all && \
     rpm --root /mnt/rootfs -e --nodeps setup
 

--- a/docker/keycloak/docker-compose.yml
+++ b/docker/keycloak/docker-compose.yml
@@ -40,8 +40,10 @@ services:
       KC_HOSTNAME_BACKCHANNEL_DYNAMIC: false
       KC_BOOTSTRAP_ADMIN_USERNAME: bootstrap-admin
       KC_BOOTSTRAP_ADMIN_PASSWORD: kc
-      KC_LOG_LEVEL: debug
+      KC_LOG_LEVEL: trace
       KC_HTTP_ENABLED: true
+      KC_HEALTH_ENABLED: true
+      KC_METRICS_ENABLED: true
     depends_on:
       kc-db:
         condition: service_healthy
@@ -51,8 +53,6 @@ services:
       traefik.http.routers.kc.rule: "Host(`kc`) || Host(`kc.localhost`)"
       traefik.http.services.kc.loadbalancer.server.scheme: http
       traefik.http.services.kc.loadbalancer.server.port: 8080
-      traefik.tcp.routers.kc.entrypoints: gl
-      traefik.tcp.routers.kc.rule: "ClientIP(`0.0.0.0/0`)"
 
 volumes:  
   kc_data:

--- a/docker/mm/config.json
+++ b/docker/mm/config.json
@@ -190,7 +190,8 @@
         "FileMaxBackups": 0,
         "FileCompress": false,
         "FileMaxQueueSize": 1000,
-        "AdvancedLoggingJSON": {}
+        "AdvancedLoggingJSON": {},
+        "Certificate": ""
     },
     "NotificationLogSettings": {
         "EnableConsole": true,
@@ -307,6 +308,9 @@
         "AboutLink": "https://mattermost.com/pl/about-mattermost",
         "HelpLink": "https://mattermost.com/pl/help/",
         "ReportAProblemLink": "https://mattermost.com/pl/report-a-bug",
+        "ReportAProblemType": "default",
+        "ReportAProblemMail": "",
+        "AllowDownloadLogs": true,
         "ForgotPasswordLink": "",
         "SupportEmail": "",
         "CustomTermsOfServiceEnabled": false,
@@ -405,6 +409,7 @@
         "LoginIdAttribute": "",
         "PictureAttribute": "",
         "SyncIntervalMinutes": 60,
+        "ReAddRemovedMembers": false,
         "SkipCertificateVerification": false,
         "PublicCertificateFile": "",
         "PrivateKeyFile": "",
@@ -614,6 +619,9 @@
                     "services": null,
                     "transcriptBackend": ""
                 }
+            },
+            "playbooks": {
+                "BotUserID": "1ikya8z3kpfpzbd4wyd6s3i5jh"
             }
         },
         "PluginStates": {


### PR DESCRIPTION
- Upgrade `Generator.Equals`, `Microsoft.EntityFrameworkCore.InMemory`, and `Serilog.Enrichers.ClientInfo`.
- Add new health check packages.
- Modify `AppConfig.cs` to include `[Equatable]` attributes and health check properties.
- Update `Program.cs` to register health checks for GitLab and OpenID APIs.
- Enhance `docker-compose.yml` with health check configurations.
- Introduce new health check classes in `Services.HealthChecks`.
- Update `config.json` with new logging and service settings.
- Modify `Dockerfile` to install additional packages (`curl`, `iproute`).
- Update `gitlab.rb` to allow monitoring from any IP address.

These changes improve health monitoring capabilities and update dependencies.