### PR TITLE
Fix MinVer not updating assembly version in container builds

### DIFF
--- a/Red55.Mattermost.OpenId.Proxy/Dockerfile
+++ b/Red55.Mattermost.OpenId.Proxy/Dockerfile
@@ -23,6 +23,8 @@ COPY ["Red55.Mattermost.OpenId.Proxy/Directory.Build.props", "Red55.Mattermost.O
 COPY ["Red55.Mattermost.OpenId.Proxy/Red55.Mattermost.OpenId.Proxy.csproj", "Red55.Mattermost.OpenId.Proxy/"]
 RUN dotnet restore "./Red55.Mattermost.OpenId.Proxy/Red55.Mattermost.OpenId.Proxy.csproj"
 COPY . .
+COPY .git/ .git/
+
 WORKDIR "/src/Red55.Mattermost.OpenId.Proxy"
 RUN dotnet build "./Red55.Mattermost.OpenId.Proxy.csproj" -c $BUILD_CONFIGURATION -o /app/build
 

--- a/Red55.Mattermost.OpenId.Proxy/Red55.Mattermost.OpenId.Proxy.csproj
+++ b/Red55.Mattermost.OpenId.Proxy/Red55.Mattermost.OpenId.Proxy.csproj
@@ -9,7 +9,9 @@
     <Platforms>x64</Platforms>
     <DockerComposeProjectPath>..\docker-compose.dcproj</DockerComposeProjectPath>
   </PropertyGroup>
-
+  <PropertyGroup>
+      <MinVerTagPrefix>v</MinVerTagPrefix>
+  </PropertyGroup>
   <ItemGroup>
     <Content Include="appsettings.*.yml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>


### PR DESCRIPTION
This PR addresses issue #18 by ensuring the .git directory is available during Docker builds, allowing MinVer to correctly determine the assembly version from Git metadata.