### PR TITLE
Fix MinVer not updating assembly version in container builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,7 @@
 **/.classpath
 **/.dockerignore
 **/.env
-**/.git
+#**/.git
 **/.gitignore
 **/.project
 **/.settings

--- a/Red55.Mattermost.OpenId.Proxy.slnx
+++ b/Red55.Mattermost.OpenId.Proxy.slnx
@@ -10,7 +10,10 @@
     <File Path=".github/workflows/ci-on-tags-master.yml" />
   </Folder>
   <Folder Name="/Solution Items/">
+    <File Path=".dockerignore" />
     <File Path=".editorconfig" />
+    <File Path=".gitattributes" />
+    <File Path=".gitignore" />
     <File Path="localhost.crt" />
     <File Path="localhost.key" />
     <File Path="README.md" />

--- a/Red55.Mattermost.OpenId.Proxy/Dockerfile
+++ b/Red55.Mattermost.OpenId.Proxy/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1.7-labs
 # See https://aka.ms/customizecontainer to learn how to customize your debug container and how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
 # This stage is used when running from VS in fast mode (Default for Debug configuration)
@@ -22,7 +23,7 @@ COPY ["Red55.Mattermost.OpenId.Proxy/Directory.Packages.props", "Red55.Mattermos
 COPY ["Red55.Mattermost.OpenId.Proxy/Directory.Build.props", "Red55.Mattermost.OpenId.Proxy/"]
 COPY ["Red55.Mattermost.OpenId.Proxy/Red55.Mattermost.OpenId.Proxy.csproj", "Red55.Mattermost.OpenId.Proxy/"]
 RUN dotnet restore "./Red55.Mattermost.OpenId.Proxy/Red55.Mattermost.OpenId.Proxy.csproj"
-COPY . .
+COPY --exclude=./git/* . .
 
 WORKDIR "/src/Red55.Mattermost.OpenId.Proxy"
 RUN --mount=type=bind,source=./.git,target=/src/Red55.Mattermost.OpenId.Proxy/.git/ dotnet build "Red55.Mattermost.OpenId.Proxy.csproj" -c $BUILD_CONFIGURATION -o /app/build

--- a/Red55.Mattermost.OpenId.Proxy/Dockerfile
+++ b/Red55.Mattermost.OpenId.Proxy/Dockerfile
@@ -23,7 +23,7 @@ COPY ["Red55.Mattermost.OpenId.Proxy/Directory.Packages.props", "Red55.Mattermos
 COPY ["Red55.Mattermost.OpenId.Proxy/Directory.Build.props", "Red55.Mattermost.OpenId.Proxy/"]
 COPY ["Red55.Mattermost.OpenId.Proxy/Red55.Mattermost.OpenId.Proxy.csproj", "Red55.Mattermost.OpenId.Proxy/"]
 RUN dotnet restore "./Red55.Mattermost.OpenId.Proxy/Red55.Mattermost.OpenId.Proxy.csproj"
-COPY --exclude=./git/* . .
+COPY --exclude=./.git/* . .
 
 WORKDIR "/src/Red55.Mattermost.OpenId.Proxy"
 RUN --mount=type=bind,source=./.git,target=/src/Red55.Mattermost.OpenId.Proxy/.git/ dotnet build "Red55.Mattermost.OpenId.Proxy.csproj" -c $BUILD_CONFIGURATION -o /app/build

--- a/Red55.Mattermost.OpenId.Proxy/Services/PatRotateService.cs
+++ b/Red55.Mattermost.OpenId.Proxy/Services/PatRotateService.cs
@@ -31,6 +31,8 @@ namespace Red55.Mattermost.OpenId.Proxy.Services
             return Task.CompletedTask;
         }
 
+        private static readonly TimeSpan RetryDelayMilliseconds = TimeSpan.FromSeconds (10);
+
         private async Task DoWork(CancellationToken cancellationToken)
         {
             try
@@ -40,9 +42,9 @@ namespace Red55.Mattermost.OpenId.Proxy.Services
                     var apiResponse = await PatApi.GetSelfAsync (cancellationToken);
                     if (!apiResponse.IsSuccessStatusCode || apiResponse.Content is null)
                     {
-                        Log.LogWarning ("Get Self Info for PAT failed {Status}. Will try again later.",
-                            apiResponse.StatusCode);
-                        await Task.Delay (10_000, cancellationToken);
+                        Log.LogWarning ("Get Self Info for PAT failed {Status}. Will try again later after {Seconds}.",
+                            apiResponse.StatusCode, RetryDelayMilliseconds.Seconds);
+                        await Task.Delay (RetryDelayMilliseconds, cancellationToken);
                         continue;
                     }
 


### PR DESCRIPTION
This PR addresses issue #18 by ensuring the .git directory is available during Docker builds, allowing MinVer to correctly determine the assembly version from Git metadata.