### PR TITLE
Fix MinVer not updating assembly version in container builds

### DIFF
--- a/.github/workflows/ci-on-tags-master.yml
+++ b/.github/workflows/ci-on-tags-master.yml
@@ -19,6 +19,7 @@ jobs:
       - uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 50
+          fetch-tags: true
       - name: meta
         uses: docker/metadata-action@v5.7.0
         with:


### PR DESCRIPTION
This PR addresses issue #18 by ensuring the .git directory is available during Docker builds, allowing MinVer to correctly determine the assembly version from Git metadata.